### PR TITLE
Add count parameter to operate_tv and operate_aircon

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This server provides the following tools:
 - **operate_tv** - Operate a TV appliance.
   - `applianceId`: Appliance id (string, required)
   - `button`: Button label (string, required)
+  - `times`: Number of times to press the button (integer, optional)
 
 - **operate_aircon** - Operate an aircon appliance.
   - `applianceId`: Appliance id (string, required)
@@ -83,6 +84,7 @@ This server provides the following tools:
   - `operationMode`: Operation mode (string, optional)
   - `temperature`: Temperature (string, optional)
   - `temperatureUnit`: Temperature unit (string, optional)
+  - `times`: Number of times to press the button (integer, optional)
 
 ## License
 

--- a/operations/appliances_aircon_settings.ts
+++ b/operations/appliances_aircon_settings.ts
@@ -10,13 +10,13 @@ export const OperateAirconOptions = z.object({
     operationMode: z.string().optional(),
     temperature: z.string().optional(),
     temperatureUnit: z.string().optional(),
-    count: z.number().default(1),
+    times: z.number().default(1),
 });
 
 export const OperateAirconSchema = OperateAirconOptions;
 
 export async function operateAircon(params: z.infer<typeof OperateAirconSchema>) {
-    const { applianceId, airDirection, airDirectionH, airVolume, button, operationMode, temperature, temperatureUnit, count } = params;
+    const { applianceId, airDirection, airDirectionH, airVolume, button, operationMode, temperature, temperatureUnit, times } = params;
 
     const formData = new FormData();
     if (airDirection) formData.append("air_direction", airDirection);
@@ -27,7 +27,7 @@ export async function operateAircon(params: z.infer<typeof OperateAirconSchema>)
     if (temperature) formData.append("temperature", temperature);
     if (temperatureUnit) formData.append("temperature_unit", temperatureUnit);
 
-    for (let i = 0; i < count; i++) {
+    for (let i = 0; i < times; i++) {
         await natureRemoRequest(
             buildUrl(`https://api.nature.global/1/appliances/${applianceId}/aircon_settings`, {}),
             {

--- a/operations/appliances_aircon_settings.ts
+++ b/operations/appliances_aircon_settings.ts
@@ -10,12 +10,13 @@ export const OperateAirconOptions = z.object({
     operationMode: z.string().optional(),
     temperature: z.string().optional(),
     temperatureUnit: z.string().optional(),
+    count: z.number().default(1),
 });
 
 export const OperateAirconSchema = OperateAirconOptions;
 
 export async function operateAircon(params: z.infer<typeof OperateAirconSchema>) {
-    const { applianceId, airDirection, airDirectionH, airVolume, button, operationMode, temperature, temperatureUnit } = params;
+    const { applianceId, airDirection, airDirectionH, airVolume, button, operationMode, temperature, temperatureUnit, count } = params;
 
     const formData = new FormData();
     if (airDirection) formData.append("air_direction", airDirection);
@@ -26,11 +27,13 @@ export async function operateAircon(params: z.infer<typeof OperateAirconSchema>)
     if (temperature) formData.append("temperature", temperature);
     if (temperatureUnit) formData.append("temperature_unit", temperatureUnit);
 
-    return natureRemoRequest(
-        buildUrl(`https://api.nature.global/1/appliances/${applianceId}/aircon_settings`, {}),
-        {
-            method: "POST",
-            body: formData,
-        }
-    );
+    for (let i = 0; i < count; i++) {
+        await natureRemoRequest(
+            buildUrl(`https://api.nature.global/1/appliances/${applianceId}/aircon_settings`, {}),
+            {
+                method: "POST",
+                body: formData,
+            }
+        );
+    }
 }

--- a/operations/appliances_tv.ts
+++ b/operations/appliances_tv.ts
@@ -4,18 +4,18 @@ import { natureRemoRequest, buildUrl } from "../common/request.js";
 export const OperateTvOptions = z.object({
     applianceId: z.string(),
     button: z.string(),
-    count: z.number().default(1),
+    times: z.number().default(1),
 });
 
 export const OperateTvSchema = OperateTvOptions;
 
 export async function operateTv(params: z.infer<typeof OperateTvSchema>) {
-    const { applianceId, button, count } = params;
+    const { applianceId, button, times } = params;
 
     const formData = new FormData();
     formData.append("button", button);
 
-    for (let i = 0; i < count; i++) {
+    for (let i = 0; i < times; i++) {
         await natureRemoRequest(
             buildUrl(`https://api.nature.global/1/appliances/${applianceId}/tv`, {}),
             {

--- a/operations/appliances_tv.ts
+++ b/operations/appliances_tv.ts
@@ -4,21 +4,24 @@ import { natureRemoRequest, buildUrl } from "../common/request.js";
 export const OperateTvOptions = z.object({
     applianceId: z.string(),
     button: z.string(),
+    count: z.number().default(1),
 });
 
 export const OperateTvSchema = OperateTvOptions;
 
 export async function operateTv(params: z.infer<typeof OperateTvSchema>) {
-    const { applianceId, button } = params;
+    const { applianceId, button, count } = params;
 
     const formData = new FormData();
     formData.append("button", button);
 
-    return natureRemoRequest(
-        buildUrl(`https://api.nature.global/1/appliances/${applianceId}/tv`, {}),
-        {
-            method: "POST",
-            body: formData,
-        }
-    );
+    for (let i = 0; i < count; i++) {
+        await natureRemoRequest(
+            buildUrl(`https://api.nature.global/1/appliances/${applianceId}/tv`, {}),
+            {
+                method: "POST",
+                body: formData,
+            }
+        );
+    }
 }


### PR DESCRIPTION
Related to #2

Add `count` parameter to `operate_tv` and `operate_aircon` functions to execute a specific button multiple times.

* **operations/appliances_tv.ts**
  - Add `count` parameter to `OperateTvOptions` schema with default value 1.
  - Loop the request in `operateTv` function based on `count` parameter.

* **operations/appliances_aircon_settings.ts**
  - Add `count` parameter to `OperateAirconOptions` schema with default value 1.
  - Loop the request in `operateAircon` function based on `count` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/noboru-i/nature-remo-mcp-server/pull/3?shareId=e6ba5cba-d03b-4c8f-a115-f2a9fd95db29).