### PR TITLE
Publish npm package by GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: '14'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
-        run: npm install
-
-      - name: Build project
-        run: npm run build
+        run: npm ci
 
       - name: Publish package
         run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish package
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-remo-mcp-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MCP Server for using the Nature Remo API",
   "license": "MIT",
   "author": "noboru-i",


### PR DESCRIPTION
Related to #1

Add GitHub Actions workflow for npm package release.

* Create `.github/workflows/release.yml` to handle the release process.
* Trigger the workflow on the creation of a new git tag.
* Install dependencies, build the project, and publish the package to npm.
* Use `NODE_AUTH_TOKEN` secret for npm authentication.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/noboru-i/nature-remo-mcp-server/pull/4?shareId=9493515e-8880-41f8-b578-db72eda8fcea).